### PR TITLE
US-03: EF Core setup for Dev

### DIFF
--- a/src/ShopMVP.Api/DatabaseOptions.cs
+++ b/src/ShopMVP.Api/DatabaseOptions.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ShopMVP.Api.DatabaseOptions;
+
+public class DatabaseOptions
+{
+    public const string Option = "ConnectionStrings";
+    [Required]
+    public string Default { get; set; } = string.Empty;
+
+}

--- a/src/ShopMVP.Api/Program.cs
+++ b/src/ShopMVP.Api/Program.cs
@@ -9,9 +9,30 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.OpenApi.Models;
 
 using ShopMVP.Api.Health;
+using ShopMVP.Api.DatabaseOptions;
+
+using ShopMVP.Infrastructure.DependencyInjection;
+
+
+
 
 var builder = WebApplication.CreateBuilder(args);
 var env = builder.Environment;
+
+//EF Core
+/*
+builder.Services.Configure<DatabaseOptions>(
+    bind section "Databse"
+    )
+    */
+
+builder.Services.AddOptions<DatabaseOptions>()
+    .Bind(builder.Configuration.GetSection(DatabaseOptions.Option))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+DatabaseOptions dbOptions = new DatabaseOptions();
+builder.Configuration.GetSection(DatabaseOptions.Option).Bind(dbOptions);
+DependencyInjection.AddPersistence(builder.Services, dbOptions.Default);
 
 // MVC
 builder.Services.AddControllers();
@@ -50,6 +71,9 @@ builder.Services.AddSwaggerGen(options =>
     var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename), includeControllerXmlComments: true);
 });
+
+
+
 var app = builder.Build();
 
 

--- a/src/ShopMVP.Api/ShopMVP.Api.csproj
+++ b/src/ShopMVP.Api/ShopMVP.Api.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ShopMVP.Api/appsettings.Development.json
+++ b/src/ShopMVP.Api/appsettings.Development.json
@@ -12,7 +12,7 @@
     }
   },
   "ConnectionStrings": {
-    "Default": "Server=(localdb)\\MSSQLLocalDB;Database=ShopMvpDev;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
+    "Default": "Server=(localdb)\\WRONGNAME;Database=WRONG;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
   }
 }
 

--- a/src/ShopMVP.Api/appsettings.Development.json
+++ b/src/ShopMVP.Api/appsettings.Development.json
@@ -4,11 +4,15 @@
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information",
-
+      "Microsoft.EntityFrameworkCore": "Warning",
       "Microsoft.Extensions.Diagnostics.HealthChecks": "Information",
       "Microsoft.AspNetCore.Diagnostics.HealthChecks": "Warning",
 
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "Default": "Server=(localdb)\\MSSQLLocalDB;Database=ShopMvpDev;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
   }
 }
+

--- a/src/ShopMVP.Api/appsettings.Development.json
+++ b/src/ShopMVP.Api/appsettings.Development.json
@@ -7,7 +7,7 @@
       "Microsoft.EntityFrameworkCore": "Warning",
       "Microsoft.Extensions.Diagnostics.HealthChecks": "Information",
       "Microsoft.AspNetCore.Diagnostics.HealthChecks": "Warning",
-
+      "Microsoft.EntityFrameworkCore.Database.Command" : "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   },

--- a/src/ShopMVP.Infrastructure/Class1.cs
+++ b/src/ShopMVP.Infrastructure/Class1.cs
@@ -1,7 +1,0 @@
-namespace ShopMVP.Infrastructure
-{
-    public class Class1
-    {
-
-    }
-}

--- a/src/ShopMVP.Infrastructure/DependencyInjection.cs
+++ b/src/ShopMVP.Infrastructure/DependencyInjection.cs
@@ -1,18 +1,11 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-using ShopMVP.Infrastructure.Persistence;
-
-namespace ShopMVP.Infrastructure
+namespace ShopMVP.Infrastructure.DependencyInjection
 {
     public static class DependencyInjection
     {
-        public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+        public static IServiceCollection AddPersistence(this IServiceCollection services, string connectionString)
         {
-            
-            services.AddDbContext<AppDbContext>(options =>
-            { }
-            );
             return services;
         }
     }

--- a/src/ShopMVP.Infrastructure/DependencyInjection.cs
+++ b/src/ShopMVP.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using ShopMVP.Infrastructure.Persistence;
+
+namespace ShopMVP.Infrastructure
+{
+    public static class DependencyInjection
+    {
+        public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+        {
+            
+            services.AddDbContext<AppDbContext>(options =>
+            { }
+            );
+            return services;
+        }
+    }
+}

--- a/src/ShopMVP.Infrastructure/DependencyInjection.cs
+++ b/src/ShopMVP.Infrastructure/DependencyInjection.cs
@@ -1,11 +1,19 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using ShopMVP.Infrastructure.Persistence;
 
 namespace ShopMVP.Infrastructure.DependencyInjection
+
 {
     public static class DependencyInjection
     {
         public static IServiceCollection AddPersistence(this IServiceCollection services, string connectionString)
         {
+            services.AddDbContext<AppDbContext>(options =>
+            options.UseSqlServer(connectionString, sql =>
+            sql.EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: TimeSpan.ParseExact("00:00:10","c",null), errorNumbersToAdd: null)));
+            
             return services;
         }
     }

--- a/src/ShopMVP.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/ShopMVP.Infrastructure/Persistence/AppDbContext.cs
@@ -4,8 +4,13 @@ namespace ShopMVP.Infrastructure.Persistence;
 
 public class AppDbContext : DbContext
 {
-    AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
     {
 
     }
+}
+
+public class IDesignTimeDbContextFactory<T>
+{
+
 }

--- a/src/ShopMVP.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/ShopMVP.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ShopMVP.Infrastructure.Persistence;
+
+public class AppDbContext : DbContext
+{
+    AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+
+    }
+}

--- a/src/ShopMVP.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/ShopMVP.Infrastructure/Persistence/AppDbContext.cs
@@ -10,9 +10,18 @@ public class AppDbContext : DbContext
 
     }
 }
-/*
+
 public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
 {
-    DbContextOptionsBuilder<AppDbContext> builder = DbContextOption;
+    public AppDbContext CreateDbContext(string[] args)
+    {
+        string connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__Default");
+        if (String.IsNullOrEmpty(connectionString))
+        {
+            connectionString = "Server=(localdb)\\MSSQLLocalDB;Database=ShopMvpDev;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True";
+        }
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseSqlServer(connectionString, sql => sql.EnableRetryOnFailure());
+        return new AppDbContext(optionsBuilder.Options);
+    }
 }
-*/

--- a/src/ShopMVP.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/ShopMVP.Infrastructure/Persistence/AppDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
 
 namespace ShopMVP.Infrastructure.Persistence;
 
@@ -9,8 +10,9 @@ public class AppDbContext : DbContext
 
     }
 }
-
-public class IDesignTimeDbContextFactory<T>
+/*
+public class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
 {
-
+    DbContextOptionsBuilder<AppDbContext> builder = DbContextOption;
 }
+*/

--- a/src/ShopMVP.Infrastructure/ShopMVP.Infrastructure.csproj
+++ b/src/ShopMVP.Infrastructure/ShopMVP.Infrastructure.csproj
@@ -5,6 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ShopMVP.Domain\ShopMVP.Domain.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Why
Setup Entity Framework Core in Infrastructure and configure Dev SQL connection, so future stories can add domain entities, migrations and seeding without extra setup.

# What
- Added EF Core packages **only** in `ShopMVP.Infrastructure` (`Core`, `Relational`, `SqlServer`, `Design` with `PrivateAssets=all`).
- Created `Persistence` folder with `AppDbContext` skeleton.
- Added `AddPersistence` method in Infrastructure (registers `AppDbContext` with `UseSqlServer`, retry policy, logging).
- Configured Dev connection string via `Options` in `ShopMVP.Api/appsettings.Development.json`.
- Verified EF tooling with design-time factory (`dotnet ef dbcontext list/info`).
- **Out of scope:** domain entities, Fluent API, migrations, seeding.

# How to test
1) In `ShopMVP.Api/appsettings.Development.json` set `ConnectionStrings:Default` for local SQL (LocalDB or SQLEXPRESS).
2) Run API in Development → app starts without DbContext errors.
3) From solution root run:
    `dotnet ef dbcontext list --project src/ShopMVP.Infrastructure --startup-project src/ShopMVP.Infrastructure dotnet ef dbcontext info  --project src/ShopMVP.Infrastructure --startup-project src/ShopMVP.Infrastructure`
    Expected: `ShopMVP.Infrastructure.Persistence.AppDbContext` listed, provider = `SqlServer`.

# Checklist (DoD)
- [x] Build green, API runs locally
- [x] `.gitignore` clean, no junk files committed
- [x] Layer references respected (Api → Infrastructure, Infrastructure → Domain)
- [x] EF Core packages only in Infrastructure
- [x] README updated with Dev DB setup instructions
- [x] Labels/milestone set in GitHub

# Risks / Notes
- No real DB yet: migrations/seeding planned for US-05.
- For EF tools always run with `--project Infrastructure --startup-project Infrastructure`.
- Do not commit secrets; Dev connection can use `Trusted_Connection` or `Integrated Security`.